### PR TITLE
Add svg-url-loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
+node_modules
 .DS_Store
 .idea

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3583,6 +3583,16 @@
         "object-assign": "4.1.1"
       }
     },
+    "file-loader": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.1.11.tgz",
+      "integrity": "sha512-TGR4HU7HUsGg6GCOPJnFk06RhWgEWFLAGWiT6rcD+GRC2keU3s9RGJ+b3Z6/U73jwwNb2gKLJ7YCrp+jvU4ALg==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "1.1.0",
+        "schema-utils": "0.4.5"
+      }
+    },
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
@@ -9767,6 +9777,16 @@
       "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
       "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
       "dev": true
+    },
+    "svg-url-loader": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/svg-url-loader/-/svg-url-loader-2.3.2.tgz",
+      "integrity": "sha1-3YaybBn+O5FPBOoQ7zlZTq3gRGQ=",
+      "dev": true,
+      "requires": {
+        "file-loader": "1.1.11",
+        "loader-utils": "1.1.0"
+      }
     },
     "svgo": {
       "version": "0.7.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "standard-loader": "^6.0.1",
     "stylelint": "^8.4.0",
     "stylelint-webpack-plugin": "^0.10.5",
+    "svg-url-loader": "^2.3.2",
     "uglifyjs-webpack-plugin": "^1.2.5",
     "url-loader": "^1.0.1",
     "webpack": "^4.12.0",
@@ -34,7 +35,10 @@
     "build": "webpack --config webpack.prod.js"
   },
   "standard": {
-    "globals": [ "_gaq", "$" ]
+    "globals": [
+      "_gaq",
+      "$"
+    ]
   },
   "engines": {
     "node": ">=8.0.0"

--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -69,6 +69,17 @@ module.exports = {
             }
           }
         }
+      },
+      {
+        test: /\.svg$/,
+        use: {
+          loader: 'svg-url-loader',
+          options: {
+            alias: {
+              './static': path.resolve(__dirname, './static')
+            }
+          }
+        }
       }
     ]
   },


### PR DESCRIPTION
When adding an SVG file as a background in SCSS, Webpack was throwing this error:

`Module parse failed: Unexpected token (1:0)
You may need an appropriate loader to handle this file type.`

By adding svg-url-loader this bug gets fixed and also it loads SVG files as utf-8 encoded DataUrl string instead of the default Base64 encoding.

There are some benefits for choosing utf-8 encoding over base64.

- Resulting string is shorter (can be ~2 times shorter for 2K-sized icons);
- Resulting string will be compressed better when using gzip compression;
- Browser parses utf-8 encoded string faster than its base64 equivalent.

More info: https://www.npmjs.com/package/svg-url-loader