### PR TITLE
Webpack transpiling and autoprefixer fixes

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -800,27 +800,92 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "6.7.7",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
-      "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
+      "version": "9.1.5",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.1.5.tgz",
+      "integrity": "sha512-kk4Zb6RUc58ld7gdosERHMF3DzIYJc2fp5sX46qEsGXQQy5bXsu8qyLjoxuY1NuQ/cJuCYnx99BfjwnRggrYIw==",
       "dev": true,
       "requires": {
-        "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000856",
+        "browserslist": "4.1.1",
+        "caniuse-lite": "1.0.30000888",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
-        "postcss": "5.2.18",
+        "postcss": "7.0.4",
         "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
-        "browserslist": {
-          "version": "1.7.7",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
-          "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000856",
-            "electron-to-chromium": "1.3.48"
+            "color-convert": "1.9.2"
+          }
+        },
+        "browserslist": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.1.1.tgz",
+          "integrity": "sha512-VBorw+tgpOtZ1BYhrVSVTzTt/3+vSE3eFUh0N2GCFK1HffceOaf32YS/bs6WiFhjDAblAFrx85jMy3BG9fBK2Q==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "1.0.30000888",
+            "electron-to-chromium": "1.3.72",
+            "node-releases": "1.0.0-alpha.12"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30000888",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000888.tgz",
+          "integrity": "sha512-vftg+5p/lPsQGpnhSo/yBuYL36ai/cyjLvU3dOPJY1kkKrekLWIy8SLm+wzjX0hpCUdFTasC4/ZT7uqw4rKOnQ==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
+          }
+        },
+        "electron-to-chromium": {
+          "version": "1.3.72",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.72.tgz",
+          "integrity": "sha512-OFbXEC01Lq7A66e3UywkvWYNN00HO1I9MAPereGe0NIXrt2MeaovL1bbY+951HKG0euUdPBe0L7yfKxgqxBMMw==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.4.tgz",
+          "integrity": "sha512-Bg1BrMZGKNOI0mkn8NtjJrOrZKgoHrl+geKJ45mTOkeY4WCsYq/mjd1BUWRgRvydHP/lA07Ys2n9m6Va5FsEsw==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.5.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -1067,6 +1132,12 @@
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
       "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+      "dev": true
+    },
+    "babel-plugin-syntax-object-rest-spread": {
+      "version": "6.13.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
       "dev": true
     },
     "babel-plugin-syntax-trailing-function-commas": {
@@ -1328,6 +1399,16 @@
       "requires": {
         "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
         "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+      "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
         "babel-runtime": "6.26.0"
       }
     },
@@ -2550,6 +2631,32 @@
         "postcss-unique-selectors": "2.0.2",
         "postcss-value-parser": "3.3.0",
         "postcss-zindex": "2.2.0"
+      },
+      "dependencies": {
+        "autoprefixer": {
+          "version": "6.7.7",
+          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
+          "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
+          "dev": true,
+          "requires": {
+            "browserslist": "1.7.7",
+            "caniuse-db": "1.0.30000856",
+            "normalize-range": "0.1.2",
+            "num2fraction": "1.2.2",
+            "postcss": "5.2.18",
+            "postcss-value-parser": "3.3.0"
+          }
+        },
+        "browserslist": {
+          "version": "1.7.7",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+          "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+          "dev": true,
+          "requires": {
+            "caniuse-db": "1.0.30000856",
+            "electron-to-chromium": "1.3.48"
+          }
+        }
       }
     },
     "csso": {
@@ -6263,6 +6370,15 @@
         "semver": "5.5.0",
         "shellwords": "0.1.1",
         "which": "1.3.1"
+      }
+    },
+    "node-releases": {
+      "version": "1.0.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.0-alpha.12.tgz",
+      "integrity": "sha512-VPB4rTPqpVyWKBHbSa4YPFme3+8WHsOSpvbp0Mfj0bWsC8TEjt4HQrLl1hsBDELlp1nB4lflSgSuGTYiuyaP7Q==",
+      "dev": true,
+      "requires": {
+        "semver": "5.5.0"
       }
     },
     "node-sass": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,8 +2,10 @@
   "description": "Starter kit for Pattern Lab",
   "devDependencies": {
     "animatewithsass": "^3.2.1",
+    "autoprefixer": "^9.1.5",
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.4",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "clean-webpack-plugin": "^0.1.19",
     "copy-webpack-plugin": "^4.5.1",
@@ -47,5 +49,9 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/moxie-lean/patternlab-starterkit-twig"
-  }
+  },
+  "browserslist": [
+    "last 2 versions",
+    "iOS >= 7"
+  ]
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,6 +52,6 @@
   },
   "browserslist": [
     "last 2 versions",
-    "iOS >= 7"
+    "iOS >= 8"
   ]
 }

--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -1,9 +1,8 @@
-const webpack = require('webpack');
-const path = require('path');
-const CleanWebpackPlugin = require("clean-webpack-plugin");
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const StyleLintPlugin = require('stylelint-webpack-plugin');
-const WebpackBuildNotifierPlugin = require('webpack-build-notifier');
+const path = require('path')
+const CleanWebpackPlugin = require('clean-webpack-plugin')
+const MiniCssExtractPlugin = require('mini-css-extract-plugin')
+const StyleLintPlugin = require('stylelint-webpack-plugin')
+const WebpackBuildNotifierPlugin = require('webpack-build-notifier')
 
 module.exports = {
   entry: {
@@ -21,7 +20,7 @@ module.exports = {
         vendor: {
           test: /node_modules\/(.*)\.js/,
           name: 'vendor',
-          chunks: "all"
+          chunks: 'all'
         }
       }
     }
@@ -30,20 +29,19 @@ module.exports = {
     rules: [
       {
         test: /(\.jsx|\.js)$/,
-        use: {
-          loader: 'babel-loader',
-          options: {
-            presets: ['env']
-          }
-        },
-        exclude: /node_modules/,
-        include: '/*/'
+        // Exclude all node modules except those who need to be transpiled by Babel. e.g. exclude: /node_modules\/(?![module1|module2])/
+        exclude: /node_modules\/(?![bootstrap])/,
+        loader: 'babel-loader',
+        query: {
+          presets: ['env'],
+          plugins: ['transform-object-rest-spread']
+        }
       },
       {
         enforce: 'pre',
         test: /(\.jsx|\.js)$/,
         loader: 'standard-loader',
-        exclude: /(node_modules|bower_components)/,
+        exclude: /(node_modules|bower_components)/
       },
       {
         test: /(\.css|\.scss|\.sass)$/,
@@ -51,12 +49,12 @@ module.exports = {
           MiniCssExtractPlugin.loader,
           {
             loader: 'css-loader',
-            options: { sourceMap: true },
+            options: { sourceMap: true }
           },
           {
             loader: 'sass-loader',
-            options: { sourceMap: true },
-          },
+            options: { sourceMap: true }
+          }
         ]
       },
       {
@@ -91,17 +89,17 @@ module.exports = {
     }),
     new CleanWebpackPlugin(['static/js', 'static/css'], {
       root: '',
-      exclude:  ['readme.md'],
-      verbose:  true,
-      dry:      false
+      exclude: ['readme.md'],
+      verbose: true,
+      dry: false
     }),
     new MiniCssExtractPlugin({
       filename: '../css/style.css',
       chunkFilename: '../css/style.css'
     }),
     new WebpackBuildNotifierPlugin({
-      title: "Webpack Build",
+      title: 'Webpack Build',
       suppressSuccess: false
     })
   ]
-};
+}

--- a/frontend/webpack.dev.js
+++ b/frontend/webpack.dev.js
@@ -1,6 +1,6 @@
-const webpack = require('webpack');
-const merge = require('webpack-merge');
-const common = require('./webpack.common.js');
+const webpack = require('webpack')
+const merge = require('webpack-merge')
+const common = require('./webpack.common.js')
 
 module.exports = merge(common, {
   mode: 'development',
@@ -13,4 +13,4 @@ module.exports = merge(common, {
       Popper: ['popper.js', 'default']
     })
   ]
-});
+})

--- a/frontend/webpack.prod.js
+++ b/frontend/webpack.prod.js
@@ -1,9 +1,8 @@
-const webpack = require('webpack');
-const path = require('path');
-const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
-const merge = require('webpack-merge');
-const common = require('./webpack.common.js');
+const webpack = require('webpack')
+const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin')
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
+const merge = require('webpack-merge')
+const common = require('./webpack.common.js')
 
 module.exports = merge(common, {
   mode: 'production',
@@ -38,11 +37,21 @@ module.exports = merge(common, {
       new OptimizeCssAssetsPlugin({
         assetNameRegExp: /\.css$/,
         cssProcessor: require('cssnano'),
-        cssProcessorOptions: { discardComments: { removeAll: true } },
+        cssProcessorOptions: {
+          discardComments: { removeAll: true },
+          safe: true,
+          autoprefixer: {
+            add: true,
+            browsers: [
+              'last 2 versions',
+              'iOS >= 7'
+            ]
+          }
+        },
         canPrint: true
       }, {
         copyUnmodified: true
       })
     ]
   }
-});
+})

--- a/frontend/webpack.prod.js
+++ b/frontend/webpack.prod.js
@@ -44,7 +44,7 @@ module.exports = merge(common, {
             add: true,
             browsers: [
               'last 2 versions',
-              'iOS >= 7'
+              'iOS >= 8'
             ]
           }
         },


### PR DESCRIPTION
The Webpack setup has two issues:

1. When a Node Module is not already transpiled, it causes some bugs on IE11 and MS Edge which won't allow to continue running the rest of js scripts. This bugs are related mostly to ES6 spread operators.  At the moment, the module causing it is the Bootstrap module, so this fix excludes this module from the "exclude" parameter in the Babel Loader rules, which cause that this module to be transpiled by Babel Loader.

`exclude: /node_modules\/(?![bootstrap])/`

This excludes everything in node_modules directory except for bootstrap module. This can be used to include all node modules that need to be transpiled by Babel. e.g. 

`exclude: /node_modules\/(?![module1|module2])/`

2. The Webpack setup for production environment has a plugin that optimizes CSS assets (optimize-css-assets-webpack-plugin), but this was removing the `-webkit` prefix which is still required by  Safari 8 or older (for iOS devices like iPad Mini, iPad Mini 2 or 3, among others).  This was fixed by adding the autoprefixer plugin and setting up the required browsers:

`browsers: [
    'last 2 versions',
    'iOS >= 8'
 ]`