### PR TITLE
Add option to load fonts in Webpack

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3696,16 +3696,6 @@
         "object-assign": "4.1.1"
       }
     },
-    "file-loader": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.1.11.tgz",
-      "integrity": "sha512-TGR4HU7HUsGg6GCOPJnFk06RhWgEWFLAGWiT6rcD+GRC2keU3s9RGJ+b3Z6/U73jwwNb2gKLJ7YCrp+jvU4ALg==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "1.1.0",
-        "schema-utils": "0.4.5"
-      }
-    },
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
@@ -9899,16 +9889,6 @@
       "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
       "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
       "dev": true
-    },
-    "svg-url-loader": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/svg-url-loader/-/svg-url-loader-2.3.2.tgz",
-      "integrity": "sha1-3YaybBn+O5FPBOoQ7zlZTq3gRGQ=",
-      "dev": true,
-      "requires": {
-        "file-loader": "1.1.11",
-        "loader-utils": "1.1.0"
-      }
     },
     "svgo": {
       "version": "0.7.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,6 @@
     "standard-loader": "^6.0.1",
     "stylelint": "^8.4.0",
     "stylelint-webpack-plugin": "^0.10.5",
-    "svg-url-loader": "^2.3.2",
     "uglifyjs-webpack-plugin": "^1.2.5",
     "url-loader": "^1.0.1",
     "webpack": "^4.12.0",

--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -32,7 +32,7 @@ module.exports = {
         use: [{
           loader: 'expose-loader',
           options: 'jQuery'
-        },{
+        }, {
           loader: 'expose-loader',
           options: '$'
         }]
@@ -79,9 +79,9 @@ module.exports = {
         }
       },
       {
-        test: /\.svg$/,
+        test: /\.(ttf|eot|woff|woff2|svg)$/,
         use: {
-          loader: 'svg-url-loader',
+          loader: 'url-loader',
           options: {
             alias: {
               './static': path.resolve(__dirname, './static')


### PR DESCRIPTION
Webpack setup was missing a loader for Font files. This PR fixes this issue.

Also I uninstalled `svg-url-loader` as it's not necessary, the `url-loader` loader does the job.