### PR TITLE
Add some CSS units to the linter whitelist

### DIFF
--- a/frontend/.stylelintrc
+++ b/frontend/.stylelintrc
@@ -15,6 +15,6 @@
       "except": ["first-nested"],
       "ignore": ["after-comment"]
     } ],
-    "unit-whitelist": ["em", "rem", "%", "s", "px"]
+    "unit-whitelist": ["em", "rem", "%", "s", "px", "deg", "vh", "vw"]
   }
 }


### PR DESCRIPTION
Added "deg", "vh" and "vw" CSS units to the linter whitelist.