### PR TITLE
Add support for customizing editor alignment options on custom blocks

### DIFF
--- a/backend/WP/Gutenberg/Blocks.php
+++ b/backend/WP/Gutenberg/Blocks.php
@@ -26,6 +26,7 @@ class Blocks {
 				'description' => 'Button block',
 				'icon'        => 'button',
 				'post_types'  => array( 'post', 'page' ),
+				'supports'    => array( 'align' => true ),
 			]
 		);
 	}

--- a/frontend/components/atoms/_style.scss
+++ b/frontend/components/atoms/_style.scss
@@ -1,3 +1,4 @@
+@import 'base/admin';
 @import 'base/breakpoints';
 @import 'base/colors';
 @import 'base/vendor';

--- a/frontend/components/atoms/base/_admin.scss
+++ b/frontend/components/atoms/base/_admin.scss
@@ -1,0 +1,32 @@
+.wp-admin {
+
+  // Show/hide alignment options for a given custom block. Replace block name below.
+  div[data-type="acf/button"] {
+
+    .components-toolbar div {
+
+      button[aria-label="Align left"] {
+        //display: none;
+      }
+
+      button[aria-label="Align center"] {
+        //display: none;
+      }
+
+      button[aria-label="Align right"] {
+        //display: none;
+      }
+
+      button[aria-label="Wide width"] {
+        //display: none;
+      }
+
+      button[aria-label="Full width"] {
+        //display: none;
+      }
+
+    }
+
+  }
+
+}


### PR DESCRIPTION
@Fcog @nelsonamaya82 I thought about creating this as a css file and enqueuing it per instructions (https://davidwalsh.name/add-custom-css-wordpress-admin), but ThemeSetup.php already does [something similar](https://github.com/wearenolte/lean-theme/blob/2d5b95fbb681d3f98516ff34cf4f80665628c858/ThemeSetup.php#L106). 