### PR TITLE
Fix Gutenberg blocks alinment button

### DIFF
--- a/backend/WP/Gutenberg/AbstractBlock.php
+++ b/backend/WP/Gutenberg/AbstractBlock.php
@@ -50,7 +50,7 @@ abstract class AbstractBlock {
 			add_action(
 				'admin_head',
 				function() use ( $args ) {
-					echo '<style>[data-type="acf/' . esc_attr( $args['name'] ) . '"] [aria-label="Change alignment"] {visibility: visible;}</style>';
+					echo '<style>[data-type="acf/' . esc_attr( $args['name'] ) . '"] [aria-label="Change alignment"] {display: flex;}</style>';
 				}
 			);
 		}

--- a/backend/WP/Gutenberg/Editor.php
+++ b/backend/WP/Gutenberg/Editor.php
@@ -129,6 +129,6 @@ class Editor {
 	 * @return void
 	 */
 	public static function admin_css() {
-		echo '<style>[data-type*="acf/"] [aria-label="Change alignment"] {visibility: hidden;}</style>';
+		echo '<style>[data-type*="acf/"] [aria-label="Change alignment"] {display: none;}</style>';
 	}
 }


### PR DESCRIPTION
This was not working as expected in the editor, as the alignment space was empty (white space) but still it was clickable. I changed the visibility hidden for display none and it works fine.