### PR TITLE
Reduce verbosity in output

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,9 +51,9 @@
     "set-up-php-lint": [
       "phpcs --config-set installed_paths vendor/wp-coding-standards/wpcs/",
       "phpcs --config-set default_standard ./phpcs.xml",
-      "phpcs --config-set show_progress 1",
+      "phpcs --config-set show_progress 0",
       "phpcs --config-set colors 1",
-      "phpcs --config-set show_warnings 1",
+      "phpcs --config-set show_warnings 0",
       "phpcs --config-set ignore_warnings_on_exit 1"
     ],
     "update-version": [


### PR DESCRIPTION
I think the progress and the tons of warnings are not useful for pipelines

![image](https://user-images.githubusercontent.com/4997549/82239019-c8216100-98fd-11ea-8f64-8e9e62b6b98e.png)
