### PR TITLE
Add the slug parameter back to the Taxonomy example

### DIFF
--- a/backend/WP/Taxonomies/Example.php
+++ b/backend/WP/Taxonomies/Example.php
@@ -29,6 +29,7 @@ class Example {
 		$tax = new Taxonomy(
 			[
 				'name'     => self::SLUG,
+				'slug'     => self::SLUG,
 				'singular' => self::NAME,
 				'plural'   => self::NAME_PLURAL,
 				'objects'  => [


### PR DESCRIPTION
Previously I removed the `slug` parameter in the Taxonomy creation example, but this is actually required by the wp-taxonomy dependency, so I added it back in this PR.