### PR TITLE
Add validation before adding data-type attribute to custom blocks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php:
   - '7.3'
 
 env:
-  - NODE_RELEASE=8
+  - NODE_RELEASE=10
 
 before_install:
   - rm -rf ~/.nvm

--- a/backend/functions/blocks.php
+++ b/backend/functions/blocks.php
@@ -92,8 +92,9 @@ add_filter(
 function lean_add_block_props( string $block_content, array $block ) : string {
 	$block_name = $block['blockName'];
 
-	$close_pos = strpos( $block_content, '>' );
-	if ( false !== $close_pos ) {
+	$close_pos     = strpos( $block_content, '>' );
+	$data_type_pos = strpos( $block_content, 'data-type' );
+	if ( false !== $close_pos && false === $data_type_pos ) {
 		$block_content = substr_replace( $block_content, ' data-type="' . $block_name . '">', $close_pos, 1 );
 	}
 


### PR DESCRIPTION
When rendering ACF Blocks in the frontend, the `data-type` attribute is rendered twice per block, so the elements end up like this:

`<section id="block_5e9c7e8e3b41f" data-type="acf/hero" class="block block-hero" data-type="acf/hero">`

This PR adds an extra validation to avoid inserting this attribute if it's already present in the element.